### PR TITLE
Deal with strict prototypes warnings

### DIFF
--- a/lib/arms.c
+++ b/lib/arms.c
@@ -91,7 +91,7 @@ double perfunc(FUNBAG *lpdf, ENVELOPE *env, double x);
 
 void display(FILE *f, ENVELOPE *env);
 
-double u_random();
+double u_random(void);
 
 /* *********************************************************************** */
 

--- a/lib/gslrandist.c
+++ b/lib/gslrandist.c
@@ -50,7 +50,7 @@
  *
  */
 
-static double rng_uniform_pos () {
+static double rng_uniform_pos (void) {
   double ran = rng_unit();
   while (ran==0)
     ran = rng_unit();


### PR DESCRIPTION
Resolves  "warning: function declaration isn’t a prototype [-Wstrict-prototypes]"
